### PR TITLE
BUG: Multiplied label names in submit buttons

### DIFF
--- a/src/BootstrapFormRenderer.php
+++ b/src/BootstrapFormRenderer.php
@@ -20,7 +20,9 @@ class BootstrapFormRenderer extends Nette\Forms\Rendering\DefaultFormRenderer
 	public function __construct(Nette\Forms\Form $form)
 	{
 		$form->onError[] = function(Nette\Forms\Form $form) {
-			static::makeBootstrap($form);
+			if ($form->getPresenter()->isAjax()) {
+				static::makeBootstrap($form);
+			}
 			static::sendErrorPayload($form);
 		};
 


### PR DESCRIPTION
Reproduction: Form contains form error (not input error) send form, with classical request (not ajax)

In case of ajax request $form->onRender() callback is not called -> that might be reason to adding makeRender into onError() callback, so funcion makeBootstrap will be called in ajax requests.

But in non-ajax requests makeBootstrap is called twice.